### PR TITLE
Correct Config Examples in README and add mention of ISDL Config Editor

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -78,8 +78,8 @@ Um das Projekt an die eigenen Vorstellungen anzupassen, stehen zwei Konfiguratio
   "Herd":
   {
     "ip": "192.168.178.201",
-    "update_time": 30
-    "cost_calc_day": true,
+    "update_time": 30,
+    "cost_calc_day": true
   }
 }
 ````

--- a/README.de.md
+++ b/README.de.md
@@ -103,7 +103,7 @@ Um das Projekt an die eigenen Vorstellungen anzupassen, stehen zwei Konfiguratio
 `cost_calc_year:` Aktiviert das Feature, dass einmal im Jahr die gesamtkosten und die Arbeit des Gerätes berechnet werden. Eingestellt wird hier der Ausführungstag und Monat.  
 
 ### ISDL Config Editor
-Wan man sich mit dem json format nicht do gut auskennt, kann man [ISDL Config Editor](isdledit.jojojux.de/editor) benutzen, um die Konfigurationsdateien in einer grafischen Benutzeroberfläche erstellen und bearbeiten kann.
+Für ein einfaches erstellen der Konfigurationsdateien auf den eigenen Aufbau, gibt es unter [ISDL Config Editor](isdledit.jojojux.de/editor) eine grafische Benutzeroberfläche. Hier kann über ein Eingebefenster z.B. der Preis/kWh eingestellt und am Ende die fertig formatierte Konfigurationsdatei heruntergeladen werden. Auch können alle Steckdosen einzel hinzugefügt werden mit den nötigen Einstellungen. Das erleichtert das Einstellen und verhindert Formatierungsfehler.
 
 ## Docker Compose Beispiel
 ````commandline

--- a/README.de.md
+++ b/README.de.md
@@ -90,6 +90,9 @@ Um das Projekt an die eigenen Vorstellungen anzupassen, stehen zwei Konfiguratio
 `cost_calc_month:` Aktiviert das Feature, dass einmal im Monat die gesamtkosten und die Arbeit des Gerätes berechnet werden. Eingestellt wird hier der Ausführungstag im Monat.  
 `cost_calc_year:` Aktiviert das Feature, dass einmal im Jahr die gesamtkosten und die Arbeit des Gerätes berechnet werden. Eingestellt wird hier der Ausführungstag und Monat.  
 
+### ISDL Config Editor
+Wan man sich mit dem json format nicht do gut auskennt, kann man [ISDL Config Editor](isdledit.jojojux.de/editor) benutzen, um die Konfigurationsdateien in einer grafischen Benutzeroberfläche erstellen und bearbeiten kann.
+
 ## Docker Compose Beispiel
 ````commandline
 version: "2"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ In order to adapt the project to the own conceptions, two configuration files ar
 `cost_calc_month:` Activates the feature that once a month the total costs and the work of the device are calculated. The execution day in the month is set here.  
 `cost_calc_year:` Activates the feature that once a year the total costs and the work of the device are calculated. The execution day and month are set here.  
 
+### ISDL Config Editor
+If you are not familiar with the json formatting, you can use [ISDL Config Editor](isdledit.jojojux.de/editor) to create the config files in a graphical user interface.
+
 ## Docker Compose Example
 ````commandline
 version: "2"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ In order to adapt the project to the own conceptions, two configuration files ar
 `cost_calc_year:` Activates the feature that once a year the total costs and the work of the device are calculated. The execution day and month are set here.
 
 ### ISDL Config Editor
-If you are not familiar with the json formatting, you can use [ISDL Config Editor](isdledit.jojojux.de/editor) to create the config files in a graphical user interface.
+For a simple creating of the configuration files, there is under [ISDL Config Editor](isdledit.jojojux.de/editor) a graphic user interface. Here can be set over a input window e.g. the price/kWh and downloaded at the end the ready formatted configuration file. Also all sockets can be added individually with the necessary settings. This facilitates the setting and prevents formatting mistakes.
+
 
 ## Docker Compose Example
 ````commandline

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In order to adapt the project to the own conceptions, two configuration files ar
 {
   "general":
   {
-    "log_level": "info"
+    "log_level": "info",
     "cost_calc_request_time": "00:00",
     "price_kwh": 0.296
   }
@@ -78,8 +78,8 @@ In order to adapt the project to the own conceptions, two configuration files ar
   "Herd":
   {
     "ip": "192.168.178.201",
-    "update_time": 30
-    "cost_calc_day": true,
+    "update_time": 30,
+    "cost_calc_day": true
   }
 }
 ````


### PR DESCRIPTION
The example config-files in json format in the readmes contained commas at wrong positions and were missing commas at some positions. This was fixed.
  
A mention of ISDL Config Editor was added to the readmes with a short explanation of what they do in a sub-heading under the configuration files section. Please review the wording of these paragraphs before merging.