### PR TITLE
error handling during message update

### DIFF
--- a/source/telegram_handler.py
+++ b/source/telegram_handler.py
@@ -391,6 +391,13 @@ def get_updates() -> list:
             "- Connection to telegram api generates an error.",
         )
         return messages
+    except KeyError as err:
+        telegrambot_watcher.failure_processing(
+            type(err).__name__,
+            err,
+            f"- Key Error during get_updates with error: {err}",
+        )
+        return messages
 
 
 def set_commands() -> None:


### PR DESCRIPTION
# What
Error handling if 'result' key is not available during telegram message update